### PR TITLE
Fix infinite acceleration

### DIFF
--- a/static/js/game.js
+++ b/static/js/game.js
@@ -290,7 +290,7 @@ function update (time, delta)
         if (player.body.blocked.down)
         {
             const absVelX = Math.abs(velX)
-            player.setVelocityX(velX - clamp(delta / 1000 * Math.sign(velX) * accelForce, -absVelX, absVelX))
+            player.setVelocityX(velX - clamp(delta / 1000 * Math.sign(velX) * Math.abs(accelForce), -absVelX, absVelX))
         }
         state = 'stand'
     }


### PR DESCRIPTION
Take absolute value of accelForce to determine deceleration to prevent players with negative accels from accelerating infinitely